### PR TITLE
Dana

### DIFF
--- a/starter-code/index.html
+++ b/starter-code/index.html
@@ -93,7 +93,7 @@
     </footer>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <!-- TODO: Include Handlebars.JS -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.6/<handlebars class="min js"></handlebars>"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.6/handlebars.js"></script>
     <script src="scripts/blogArticles.js"></script>
     <script src="scripts/article.js"></script>
     <script src="scripts/articleView.js"></script>

--- a/starter-code/index.html
+++ b/starter-code/index.html
@@ -41,7 +41,7 @@
       <option value="{{author}}">{{author}}</option>
     </script>
     <script id="categoryFilterTemplate" type="text/x-handlebars-template">
-      <option value="{{noRepeats this.category}}">{{noRepeats this.category}}</option>
+      <option value="{{noRepeats category}}">{{noRepeats category}}</option>
     </script>
   </head>
   <body>

--- a/starter-code/index.html
+++ b/starter-code/index.html
@@ -18,15 +18,15 @@
     - Insert correct placeholder properties based on our Model.
     -->
     <script id="articleTemplate" type="text/x-handlebars-template">
-      <article class="clearfix" data-author="{{ author }}" data-category="{{ category }}">
+      <article class="clearfix" data-author="{{author}}" data-category="{{category}}">
         <header>
-          <h1>{{ title }}</h1>
+          <h1>{{title}}</h1>
           <div class="byline">
-            By <address><a href="{{ authorUrl }}">{{ author }}</a></address>
+            By <address><a href="{{authorUrl}}">{{author}}</a></address>
             {{publishStatus}}
           </div>
         </header>
-        <section class="article-body">{{{ body }}}</section>
+        <section class="article-body">{{{body}}}</section>
         <a href="#" class="read-on">Read on &rarr;</a>
       </article>
     </script>

--- a/starter-code/index.html
+++ b/starter-code/index.html
@@ -93,7 +93,7 @@
     </footer>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <!-- TODO: Include Handlebars.JS -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.6/handlebars.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.6/<handlebars class="min js"></handlebars>"></script>
     <script src="scripts/blogArticles.js"></script>
     <script src="scripts/article.js"></script>
     <script src="scripts/articleView.js"></script>

--- a/starter-code/index.html
+++ b/starter-code/index.html
@@ -17,16 +17,16 @@
       specify the type!
     - Insert correct placeholder properties based on our Model.
     -->
-    <script id=" " type=" ">
-      <article class="clearfix" data-author=" " data-category=" ">
+    <script id="articleTemplate" type="text/x-handlebars-template">
+      <article class="clearfix" data-author="{{ author }}" data-category="{{ category }}">
         <header>
-          <h1> </h1>
+          <h1>{{ title }}</h1>
           <div class="byline">
-            By <address><a href=" "> </a></address>
+            By <address><a href="{{ authorUrl }}">{{ author }}</a></address>
             {{publishStatus}}
           </div>
         </header>
-        <section class="article-body"> </section>
+        <section class="article-body">{{{ body }}}</section>
         <a href="#" class="read-on">Read on &rarr;</a>
       </article>
     </script>
@@ -93,6 +93,7 @@
     </footer>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <!-- TODO: Include Handlebars.JS -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.6/handlebars.min.js"></script>
     <script src="scripts/blogArticles.js"></script>
     <script src="scripts/article.js"></script>
     <script src="scripts/articleView.js"></script>

--- a/starter-code/index.html
+++ b/starter-code/index.html
@@ -37,6 +37,12 @@
         option element (one for author, one for category), and
         render the list once you have data to populate it with.
        -->
+    <script id="authorFilterTemplate" type="text/x-handlebars-template">
+      <option value="{{author}}">{{author}}</option>
+    </script>
+    <script id="categoryFilterTemplate" type="text/x-handlebars-template">
+      <option value="{{category}}">{{category}}</option>
+    </script>
   </head>
   <body>
     <header class="site-header clearfix">

--- a/starter-code/index.html
+++ b/starter-code/index.html
@@ -41,7 +41,7 @@
       <option value="{{author}}">{{author}}</option>
     </script>
     <script id="categoryFilterTemplate" type="text/x-handlebars-template">
-      <option value="{{category}}">{{category}}</option>
+      <option value="{{noRepeats this.category}}">{{noRepeats this.category}}</option>
     </script>
   </head>
   <body>

--- a/starter-code/scripts/article.js
+++ b/starter-code/scripts/article.js
@@ -33,8 +33,14 @@ Article.prototype.populateAuthorFilter = function() {
 };
 
 Article.prototype.populateCategoryFilter = function() {
+  Handlebars.registerHelper('noRepeats', function(cat) {
+    if ($(`#category-filter option[value = cat]`).length === 0) {
+      cat = cat || '';
+      return categoryFilterCompiler(this);
+    }
+  });
   var categoryFilterCompiler = Handlebars.compile($('#categoryFilterTemplate').html());
-  return categoryFilterCompiler(this);
+  // return categoryFilterCompiler(this);
 };
 
 ourLocalData.sort(function(a,b) {

--- a/starter-code/scripts/article.js
+++ b/starter-code/scripts/article.js
@@ -24,7 +24,12 @@ Article.prototype.toHtml = function() {
   //       - Now "compile" your template with Handlebars.
   //       - Don't forget to return your template for this article.
   var blackMagicCompile = Handlebars.compile($('#articleTemplate').html());
-  $('#articles').append(blackMagicCompile(this));
+  return blackMagicCompile(this);
+};
+
+Article.prototype.populateFilters = function() {
+  var authorFilterCompiler = Handlebars.compile($('#authorFilterTemplate').html());
+  return authorFilterCompiler(this);
 };
 
 ourLocalData.sort(function(a,b) {
@@ -37,4 +42,5 @@ ourLocalData.forEach(function(ele) {
 
 articles.forEach(function(a){
   $('#articles').append(a.toHtml());
+  $('#author-filter').append(a.populateFilters());
 });

--- a/starter-code/scripts/article.js
+++ b/starter-code/scripts/article.js
@@ -27,9 +27,14 @@ Article.prototype.toHtml = function() {
   return blackMagicCompile(this);
 };
 
-Article.prototype.populateFilters = function() {
+Article.prototype.populateAuthorFilter = function() {
   var authorFilterCompiler = Handlebars.compile($('#authorFilterTemplate').html());
   return authorFilterCompiler(this);
+};
+
+Article.prototype.populateCategoryFilter = function() {
+  var categoryFilterCompiler = Handlebars.compile($('#categoryFilterTemplate').html());
+  return categoryFilterCompiler(this);
 };
 
 ourLocalData.sort(function(a,b) {
@@ -42,5 +47,6 @@ ourLocalData.forEach(function(ele) {
 
 articles.forEach(function(a){
   $('#articles').append(a.toHtml());
-  $('#author-filter').append(a.populateFilters());
+  $('#author-filter').append(a.populateAuthorFilter());
+  $('#category-filter').append(a.populateCategoryFilter());
 });

--- a/starter-code/scripts/article.js
+++ b/starter-code/scripts/article.js
@@ -24,7 +24,7 @@ Article.prototype.toHtml = function() {
   //       - Now "compile" your template with Handlebars.
   //       - Don't forget to return your template for this article.
   var blackMagicCompile = Handlebars.compile($('#articleTemplate').html());
-  $('#articles').append(blackMagicCompile(ourLocalData));
+  $('#articles').append(blackMagicCompile(this));
 };
 
 ourLocalData.sort(function(a,b) {

--- a/starter-code/scripts/article.js
+++ b/starter-code/scripts/article.js
@@ -34,8 +34,7 @@ Article.prototype.populateAuthorFilter = function() {
 
 Article.prototype.populateCategoryFilter = function() {
   Handlebars.registerHelper('noRepeats', function(cat) {
-    if ($(`#category-filter option[value = cat]`).length === 0) {
-      cat = cat || '';
+    if ($(`#category-filter option[value = "cat"]`).length === 0) {
       return categoryFilterCompiler(this);
     }
   });

--- a/starter-code/scripts/article.js
+++ b/starter-code/scripts/article.js
@@ -33,13 +33,15 @@ Article.prototype.populateAuthorFilter = function() {
 };
 
 Article.prototype.populateCategoryFilter = function() {
-  Handlebars.registerHelper('noRepeats', function(cat) {
-    if ($(`#category-filter option[value = "cat"]`).length === 0) {
-      return categoryFilterCompiler(this);
+  var categoryFilterCompiler = Handlebars.compile($('#categoryFilterTemplate').html());
+  Handlebars.registerHelper('noRepeats', function() {
+    if ($('#category-filter option[value="' + this.category + '"]').length === 0) {
+      return this.category;
+    } else {
+      return $('option:contains([object Object])').hide();
     }
   });
-  var categoryFilterCompiler = Handlebars.compile($('#categoryFilterTemplate').html());
-  // return categoryFilterCompiler(this);
+  return categoryFilterCompiler(this);
 };
 
 ourLocalData.sort(function(a,b) {

--- a/starter-code/scripts/article.js
+++ b/starter-code/scripts/article.js
@@ -17,12 +17,14 @@ Article.prototype.toHtml = function() {
   //   The result is added to the object as a new property, which can then be referenced
   //   by a key in the template. For example, you might want to display how old a post is,
   //   or say "(draft)" if it has no publication date:
-  this.daysAgo = parseInt((new Date() - new Date(this.publishedOn))/60/60/24/1000);
+  this.daysAgo = parseInt((new Date() - new Date(this.publishedOn)) / 60 / 60 / 24 / 1000);
   this.publishStatus = this.publishedOn ? 'published ' + this.daysAgo + ' days ago' : '(draft)';
   // TODO: Use handlebars to render your articles!
   //       - Select your template from the DOM.
   //       - Now "compile" your template with Handlebars.
   //       - Don't forget to return your template for this article.
+  var blackMagicCompile = Handlebars.compile($('#articleTemplate').html());
+  $('#articles').append(blackMagicCompile(ourLocalData));
 };
 
 ourLocalData.sort(function(a,b) {

--- a/starter-code/scripts/articleView.js
+++ b/starter-code/scripts/articleView.js
@@ -4,18 +4,20 @@
 var articleView = {};
 
 articleView.populateFilters = function() {
-  $('article').not('.template').each(function() {
-    var authorName, category, optionTag;
-    authorName = $(this).find('address a').text();
-    optionTag = '<option value="' + authorName + '">' + authorName + '</option>';
-    $('#author-filter').append(optionTag);
-
-    category = $(this).attr('data-category');
-    optionTag = '<option value="' + category + '">' + category + '</option>';
-    if ($('#category-filter option[value="' + category + '"]').length === 0) {
-      $('#category-filter').append(optionTag);
-    }
-  });
+  // $('article').not('.template').each(function() {
+  //   var authorName, category, optionTag;
+  //   authorName = $(this).find('address a').text();
+  //   optionTag = '<option value="' + authorName + '">' + authorName + '</option>';
+  //   $('#author-filter').append(optionTag);
+  //
+  //   category = $(this).attr('data-category');
+  //   optionTag = '<option value="' + category + '">' + category + '</option>';
+  //   if ($('#category-filter option[value="' + category + '"]').length === 0) {
+  //     $('#category-filter').append(optionTag);
+  //   }
+  // });
+  var authorFilterCompiler = Handlebars.compile($('#authorFilterTemplate').html());
+  $('#author-filter').append(authorFilterCompiler(this));
 };
 
 articleView.handleAuthorFilter = function() {
@@ -62,7 +64,9 @@ articleView.setTeasers = function() {
   });
 };
 
-articleView.populateFilters();
+articles.forEach(function() {
+  $('author-filter').append(articleView.populateFilters());
+});
 articleView.handleCategoryFilter();
 articleView.handleAuthorFilter();
 articleView.handleMainNav();

--- a/starter-code/scripts/articleView.js
+++ b/starter-code/scripts/articleView.js
@@ -17,7 +17,7 @@ articleView.populateFilters = function() {
   //   }
   // });
   var authorFilterCompiler = Handlebars.compile($('#authorFilterTemplate').html());
-  $('#author-filter').append(authorFilterCompiler(this));
+  $('#author-filter').append(authorFilterCompiler());
 };
 
 articleView.handleAuthorFilter = function() {
@@ -64,9 +64,6 @@ articleView.setTeasers = function() {
   });
 };
 
-articles.forEach(function() {
-  $('author-filter').append(articleView.populateFilters());
-});
 articleView.handleCategoryFilter();
 articleView.handleAuthorFilter();
 articleView.handleMainNav();

--- a/starter-code/scripts/articleView.js
+++ b/starter-code/scripts/articleView.js
@@ -3,23 +3,6 @@
 // Configure a view object, to hold all our functions for dynamic updates and article-related event handlers.
 var articleView = {};
 
-articleView.populateFilters = function() {
-  // $('article').not('.template').each(function() {
-  //   var authorName, category, optionTag;
-  //   authorName = $(this).find('address a').text();
-  //   optionTag = '<option value="' + authorName + '">' + authorName + '</option>';
-  //   $('#author-filter').append(optionTag);
-  //
-  //   category = $(this).attr('data-category');
-  //   optionTag = '<option value="' + category + '">' + category + '</option>';
-  //   if ($('#category-filter option[value="' + category + '"]').length === 0) {
-  //     $('#category-filter').append(optionTag);
-  //   }
-  // });
-  var authorFilterCompiler = Handlebars.compile($('#authorFilterTemplate').html());
-  $('#author-filter').append(authorFilterCompiler());
-};
-
 articleView.handleAuthorFilter = function() {
   $('#author-filter').on('change', function() {
     if ($(this).val()) {


### PR DESCRIPTION
Refactored the toHtml() prototype method of the Article object to return the populated template rather than append it to the DOM. The appending happens later when the method is called for each of the instances of Article.

I also refactored the filters to use Handlebars templates.

I would love some feedback on why the last duplicate 'category' filter object is not being hidden. I'm sure that there is a better way to accomplish eliminating the duplicates.